### PR TITLE
assert() -> AWS_ASSERT(), removed assert includes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,6 @@ CheckOptions:
   - key:             google-runtime-int.TypeSufix
     value:           '_t'
   - key:             fuchsia-restrict-system-includes.Includes
-    value:           '*,-stdint.h,-stdbool.h'
+    value:           '*,-stdint.h,-stdbool.h,-assert.h'
 
 ...

--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ not match a symbol. This is useful for verifying the padding bits of a stream.
 For example, to validate that a stream ends in all 1's (like HPACK requires),
 you could do the following:
 ```c
-assert(decoder->working_bits == UINT64_MAX << (64 - decoder->num_bits));
+AWS_ASSERT(decoder->working_bits == UINT64_MAX << (64 - decoder->num_bits));
 ```

--- a/include/aws/testing/compression/huffman.h
+++ b/include/aws/testing/compression/huffman.h
@@ -37,8 +37,8 @@
  * following (pseudo-code):
  *
  * \code{c} for (cp in code_points) {
- *     assert(my_coder->encode(cp.symbol) == cp.pattern);
- *     assert(my_coder->decode(cp.pattern) == cp.symbol);
+ *     AWS_ASSERT(my_coder->encode(cp.symbol) == cp.pattern);
+ *     AWS_ASSERT(my_coder->decode(cp.pattern) == cp.symbol);
  * }
  * \endcode
  */

--- a/source/huffman.c
+++ b/source/huffman.c
@@ -19,16 +19,14 @@
 
 #include <aws/common/byte_buf.h>
 
-#include <assert.h>
-
 #define BITSIZEOF(val) (sizeof(val) * 8)
 
 static uint8_t MAX_PATTERN_BITS = BITSIZEOF(((struct aws_huffman_code *)0)->pattern);
 
 void aws_huffman_encoder_init(struct aws_huffman_encoder *encoder, struct aws_huffman_symbol_coder *coder) {
 
-    assert(encoder);
-    assert(coder);
+    AWS_ASSERT(encoder);
+    AWS_ASSERT(coder);
 
     AWS_ZERO_STRUCT(*encoder);
     encoder->coder = coder;
@@ -37,7 +35,7 @@ void aws_huffman_encoder_init(struct aws_huffman_encoder *encoder, struct aws_hu
 
 void aws_huffman_encoder_reset(struct aws_huffman_encoder *encoder) {
 
-    assert(encoder);
+    AWS_ASSERT(encoder);
 
     uint8_t eos_padding = encoder->eos_padding;
     aws_huffman_encoder_init(encoder, encoder->coder);
@@ -46,8 +44,8 @@ void aws_huffman_encoder_reset(struct aws_huffman_encoder *encoder) {
 
 void aws_huffman_decoder_init(struct aws_huffman_decoder *decoder, struct aws_huffman_symbol_coder *coder) {
 
-    assert(decoder);
-    assert(coder);
+    AWS_ASSERT(decoder);
+    AWS_ASSERT(coder);
 
     AWS_ZERO_STRUCT(*decoder);
     decoder->coder = coder;
@@ -129,10 +127,10 @@ int aws_huffman_encode(
     struct aws_byte_cursor *to_encode,
     struct aws_byte_buf *output) {
 
-    assert(encoder);
-    assert(encoder->coder);
-    assert(to_encode);
-    assert(output);
+    AWS_ASSERT(encoder);
+    AWS_ASSERT(encoder->coder);
+    AWS_ASSERT(to_encode);
+    AWS_ASSERT(output);
 
     if (output->len == output->capacity) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
@@ -166,7 +164,7 @@ int aws_huffman_encode(
     eos_cp.pattern = encoder->eos_padding;
     eos_cp.num_bits = state.bit_pos;
     encode_write_bit_pattern(&state, eos_cp);
-    assert(state.bit_pos == 8);
+    AWS_ASSERT(state.bit_pos == 8);
 
     return AWS_OP_SUCCESS;
 }
@@ -202,10 +200,10 @@ int aws_huffman_decode(
     struct aws_byte_cursor *to_decode,
     struct aws_byte_buf *output) {
 
-    assert(decoder);
-    assert(decoder->coder);
-    assert(to_decode);
-    assert(output);
+    AWS_ASSERT(decoder);
+    AWS_ASSERT(decoder->coder);
+    AWS_ASSERT(to_decode);
+    AWS_ASSERT(output);
 
     if (output->len == output->capacity) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
@@ -259,5 +257,5 @@ int aws_huffman_decode(
     }
 
     /* This case is unreachable */
-    assert(0);
+    AWS_ASSERT(0);
 }

--- a/source/huffman_generator/generator.c
+++ b/source/huffman_generator/generator.c
@@ -321,8 +321,6 @@ int main(int argc, char *argv[]) {
         "\n"
         "#include <aws/compression/huffman.h>\n"
         "\n"
-        "#include <assert.h>\n"
-        "\n"
         "static struct aws_huffman_code code_points[] = {\n");
 
     for (size_t i = 0; i < num_code_points; ++i) {

--- a/tests/test_huffman_static.c
+++ b/tests/test_huffman_static.c
@@ -17,8 +17,6 @@
 
 #include <aws/compression/huffman.h>
 
-#include <assert.h>
-
 static struct aws_huffman_code code_points[] = {
     {.pattern = 0x32e, .num_bits = 10}, /* ' ' 0 */
     {.pattern = 0x32f, .num_bits = 10}, /* ' ' 1 */


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
