### PR TITLE
Fix warnings about including assert.h

### DIFF
--- a/source/huffman_generator/generator.c
+++ b/source/huffman_generator/generator.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include <assert.h>
+#include <assert.h> /* NOLINT(fuchsia-restrict-system-includes) */
 #include <ctype.h>
 #include <stdint.h> /* NOLINT(fuchsia-restrict-system-includes) */
 #include <stdio.h>


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
