### PR TITLE
Don't add padding byte if encoded buffer fills byte

### DIFF
--- a/include/aws/testing/compression/huffman.h
+++ b/include/aws/testing/compression/huffman.h
@@ -71,7 +71,8 @@ struct huffman_test_code_point {
  *
  * \param[in]   coder           The symbol coder to test
  * \param[in]   input           The buffer to test
- * \param[in]   input_size      The size of input
+ * \param[in]   size            The size of input
+ * \param[in]   encoded_size    The length of the encoded buffer. Pass 0 to skip check.
  * \param[out]  error_string    In case of failure, the error string to report
  *
  * \return AWS_OP_SUCCESS on success, AWS_OP_FAILURE on failure (error_string
@@ -81,6 +82,7 @@ int huffman_test_transitive(
     struct aws_huffman_symbol_coder *coder,
     const char *input,
     size_t size,
+    size_t encoded_size,
     const char **error_string);
 
 /**
@@ -89,7 +91,8 @@ int huffman_test_transitive(
  *
  * \param[in]   coder               The symbol coder to test
  * \param[in]   input               The buffer to test
- * \param[in]   input_size          The size of input
+ * \param[in]   size                The size of input
+ * \param[in]   encoded_size        The length of the encoded buffer. Pass 0 to skip check.
  * \param[in]   output_chunk_size   The amount of output to write at once
  * \param[out]  error_string        In case of failure, the error string to
  * report
@@ -101,6 +104,7 @@ int huffman_test_transitive_chunked(
     struct aws_huffman_symbol_coder *coder,
     const char *input,
     size_t size,
+    size_t encoded_size,
     size_t output_chunk_size,
     const char **error_string);
 

--- a/include/aws/testing/compression/huffman.inl
+++ b/include/aws/testing/compression/huffman.inl
@@ -27,6 +27,7 @@ int huffman_test_transitive(
     struct aws_huffman_symbol_coder *coder,
     const char *input,
     size_t size,
+    size_t encoded_size,
     const char **error_string) {
 
     struct aws_huffman_encoder encoder;
@@ -52,6 +53,10 @@ int huffman_test_transitive(
     }
     if (to_encode.len != 0) {
         *error_string = "not all data encoded";
+        return AWS_OP_ERR;
+    }
+    if (encoded_size && intermediate_buf.len != encoded_size) {
+        *error_string = "encoded length is incorrect";
         return AWS_OP_ERR;
     }
 
@@ -82,6 +87,7 @@ int huffman_test_transitive_chunked(
     struct aws_huffman_symbol_coder *coder,
     const char *input,
     size_t size,
+    size_t encoded_size,
     size_t output_chunk_size,
     const char **error_string) {
 
@@ -129,6 +135,10 @@ int huffman_test_transitive_chunked(
     }
     if (intermediate_buf.len > intermediate_buffer_size) {
         *error_string = "too much data encoded";
+        return AWS_OP_ERR;
+    }
+    if (encoded_size && intermediate_buf.len != encoded_size) {
+        *error_string = "encoded length is incorrect";
         return AWS_OP_ERR;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_test_case(huffman_decoder_partial_input)
 add_test_case(huffman_decoder_partial_output)
 
 add_test_case(huffman_transitive)
+add_test_case(huffman_transitive_even_bytes)
 add_test_case(huffman_transitive_all_code_points)
 add_test_case(huffman_transitive_chunked)
 

--- a/tests/fuzz/transitive.c
+++ b/tests/fuzz/transitive.c
@@ -26,7 +26,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
 
     const char *error_message = NULL;
-    int result = huffman_test_transitive(test_get_coder(), (const char *)data, size, &error_message);
+    int result = huffman_test_transitive(test_get_coder(), (const char *)data, size, 0, &error_message);
     ASSERT_SUCCESS(result, error_message);
 
     return 0; // Non-zero return values are reserved for future use.

--- a/tests/fuzz/transitive_chunked.c
+++ b/tests/fuzz/transitive_chunked.c
@@ -31,7 +31,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
         const char *error_message = NULL;
         int result =
-            huffman_test_transitive_chunked(test_get_coder(), (const char *)data, size, step_size, &error_message);
+            huffman_test_transitive_chunked(test_get_coder(), (const char *)data, size, 0, step_size, &error_message);
         ASSERT_SUCCESS(result, error_message);
     }
 

--- a/tests/huffman_test.c
+++ b/tests/huffman_test.c
@@ -347,7 +347,20 @@ static int test_huffman_transitive(struct aws_allocator *allocator, void *ctx) {
     /* Test encoding a short url and immediately decoding it */
 
     const char *error_message = NULL;
-    int result = huffman_test_transitive(test_get_coder(), s_url_string, URL_STRING_LEN, &error_message);
+    int result = huffman_test_transitive(test_get_coder(), s_url_string, URL_STRING_LEN, ENCODED_URL_LEN, &error_message);
+    ASSERT_SUCCESS(result, error_message);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(huffman_transitive_even_bytes, test_huffman_transitive_even_bytes)
+static int test_huffman_transitive_even_bytes(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+    /* Test encoding a string that encodes to a multiple of 8 bits */
+
+    const char *error_message = NULL;
+    int result = huffman_test_transitive(test_get_coder(), "cdfh", 4, 3, &error_message);
     ASSERT_SUCCESS(result, error_message);
 
     return AWS_OP_SUCCESS;
@@ -361,7 +374,7 @@ static int test_huffman_transitive_all_code_points(struct aws_allocator *allocat
      * characters and immediately decoding it */
 
     const char *error_message = NULL;
-    int result = huffman_test_transitive(test_get_coder(), s_all_codes, ALL_CODES_LEN, &error_message);
+    int result = huffman_test_transitive(test_get_coder(), s_all_codes, ALL_CODES_LEN, ENCODED_CODES_LEN, &error_message);
     ASSERT_SUCCESS(result, error_message);
 
     return AWS_OP_SUCCESS;
@@ -379,7 +392,7 @@ static int test_huffman_transitive_chunked(struct aws_allocator *allocator, void
 
         const char *error_message = NULL;
         int result =
-            huffman_test_transitive_chunked(test_get_coder(), s_all_codes, ALL_CODES_LEN, step_size, &error_message);
+            huffman_test_transitive_chunked(test_get_coder(), s_all_codes, ALL_CODES_LEN, ENCODED_CODES_LEN, step_size, &error_message);
         ASSERT_SUCCESS(result, error_message);
     }
 

--- a/tests/huffman_test.c
+++ b/tests/huffman_test.c
@@ -347,7 +347,8 @@ static int test_huffman_transitive(struct aws_allocator *allocator, void *ctx) {
     /* Test encoding a short url and immediately decoding it */
 
     const char *error_message = NULL;
-    int result = huffman_test_transitive(test_get_coder(), s_url_string, URL_STRING_LEN, ENCODED_URL_LEN, &error_message);
+    int result =
+        huffman_test_transitive(test_get_coder(), s_url_string, URL_STRING_LEN, ENCODED_URL_LEN, &error_message);
     ASSERT_SUCCESS(result, error_message);
 
     return AWS_OP_SUCCESS;
@@ -374,7 +375,8 @@ static int test_huffman_transitive_all_code_points(struct aws_allocator *allocat
      * characters and immediately decoding it */
 
     const char *error_message = NULL;
-    int result = huffman_test_transitive(test_get_coder(), s_all_codes, ALL_CODES_LEN, ENCODED_CODES_LEN, &error_message);
+    int result =
+        huffman_test_transitive(test_get_coder(), s_all_codes, ALL_CODES_LEN, ENCODED_CODES_LEN, &error_message);
     ASSERT_SUCCESS(result, error_message);
 
     return AWS_OP_SUCCESS;
@@ -391,8 +393,8 @@ static int test_huffman_transitive_chunked(struct aws_allocator *allocator, void
         const size_t step_size = s_step_sizes[i];
 
         const char *error_message = NULL;
-        int result =
-            huffman_test_transitive_chunked(test_get_coder(), s_all_codes, ALL_CODES_LEN, ENCODED_CODES_LEN, step_size, &error_message);
+        int result = huffman_test_transitive_chunked(
+            test_get_coder(), s_all_codes, ALL_CODES_LEN, ENCODED_CODES_LEN, step_size, &error_message);
         ASSERT_SUCCESS(result, error_message);
     }
 


### PR DESCRIPTION
Before this PR, if an encoded buffer was an even number of bytes (no extra bits), an entire byte of padding was written. This PR fixes that issue, and adds a test verifying expected encoded lengths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
