### PR TITLE
Huffman decoder will grow output buffer, if you want it to

### DIFF
--- a/include/aws/compression/huffman.h
+++ b/include/aws/compression/huffman.h
@@ -87,6 +87,7 @@ struct aws_huffman_encoder {
 struct aws_huffman_decoder {
     /* Param */
     struct aws_huffman_symbol_coder *coder;
+    bool allow_growth;
 
     /* State */
     uint64_t working_bits;
@@ -150,7 +151,8 @@ int aws_huffman_encode(
  *
  * \param[in]       decoder         The decoder object to use
  * \param[in]       to_decode       The encoded byte buffer to read from
- * \param[in]       output          The buffer to write decoded symbols to
+ * \param[in]       output          The buffer to write decoded symbols to.
+ *                                  If decoder is set to allow growth, capacity will be increased when necessary.
  *
  * \return AWS_OP_SUCCESS if encoding is successful, AWS_OP_ERR otherwise
  */
@@ -159,6 +161,13 @@ int aws_huffman_decode(
     struct aws_huffman_decoder *decoder,
     struct aws_byte_cursor *to_decode,
     struct aws_byte_buf *output);
+
+/**
+ * Set whether or not to increase capacity when the output buffer fills up while decoding.
+ * This is false by default.
+ */
+AWS_COMPRESSION_API
+void aws_huffman_decoder_allow_growth(struct aws_huffman_decoder *decoder, bool allow_growth);
 
 AWS_EXTERN_C_END
 

--- a/source/huffman.c
+++ b/source/huffman.c
@@ -273,6 +273,7 @@ int aws_huffman_decode(
             /* Check if we've hit the end of the output buffer.
              * Grow buffer, or raise error, depending on settings */
             if (decoder->allow_growth) {
+                /* Double the capacity */
                 if (aws_byte_buf_reserve_relative(output, output->capacity)) {
                     return AWS_OP_ERR;
                 }

--- a/source/huffman.c
+++ b/source/huffman.c
@@ -235,10 +235,6 @@ int aws_huffman_decode(
     AWS_ASSERT(to_decode);
     AWS_ASSERT(output);
 
-    if (output->len == output->capacity) {
-        return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
-    }
-
     struct decoder_state state;
     state.decoder = decoder;
     state.input_cursor = to_decode;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_test_case(huffman_decoder)
 add_test_case(huffman_decoder_all_code_points)
 add_test_case(huffman_decoder_partial_input)
 add_test_case(huffman_decoder_partial_output)
+add_test_case(huffman_decoder_allow_growth)
 
 add_test_case(huffman_transitive)
 add_test_case(huffman_transitive_even_bytes)

--- a/tests/huffman_test.c
+++ b/tests/huffman_test.c
@@ -340,6 +340,28 @@ static int test_huffman_decoder_partial_output(struct aws_allocator *allocator, 
     return AWS_OP_SUCCESS;
 }
 
+AWS_TEST_CASE(huffman_decoder_allow_growth, test_huffman_decoder_allow_growth)
+static int test_huffman_decoder_allow_growth(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    /* Test that decoder will grow output buffer if allow-growth is set */
+
+    struct aws_huffman_decoder decoder;
+    aws_huffman_decoder_init(&decoder, test_get_coder());
+    aws_huffman_decoder_allow_growth(&decoder, true);
+
+    struct aws_byte_buf output_buf;
+    ASSERT_SUCCESS(aws_byte_buf_init(&output_buf, allocator, 1 /* way too small */));
+
+    struct aws_byte_cursor to_decode = aws_byte_cursor_from_array(s_encoded_url, ENCODED_URL_LEN);
+    ASSERT_SUCCESS(aws_huffman_decode(&decoder, &to_decode, &output_buf));
+
+    ASSERT_UINT_EQUALS(0, to_decode.len);
+    ASSERT_BIN_ARRAYS_EQUALS(s_url_string, URL_STRING_LEN, output_buf.buffer, output_buf.len);
+
+    aws_byte_buf_clean_up(&output_buf);
+    return AWS_OP_SUCCESS;
+}
+
 AWS_TEST_CASE(huffman_transitive, test_huffman_transitive)
 static int test_huffman_transitive(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;


### PR DESCRIPTION
Add option to grow output buffer while decoding.

The alternative is to always have the output buffer be big enough for the largest string you allow, but that's probably a waste of space in the normal case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
