### PR TITLE
Moved .inl test symbols into source file, fixes downstream swift build

### DIFF
--- a/include/aws/testing/compression/huffman.h
+++ b/include/aws/testing/compression/huffman.h
@@ -98,6 +98,6 @@ int huffman_test_transitive_chunked(
     size_t output_chunk_size,
     const char **error_string);
 
-#include <aws/testing/compression/huffman.inl>
+/*#include <aws/testing/compression/huffman.inl>*/
 
 #endif /* AWS_TESTING_COMPRESSION_HUFFMAN_H */

--- a/include/aws/testing/compression/huffman.h
+++ b/include/aws/testing/compression/huffman.h
@@ -68,6 +68,7 @@ struct huffman_test_code_point {
  * \return AWS_OP_SUCCESS on success, AWS_OP_FAILURE on failure (error_string
  * will be set)
  */
+AWS_COMPRESSION_API
 int huffman_test_transitive(
     struct aws_huffman_symbol_coder *coder,
     const char *input,
@@ -90,6 +91,7 @@ int huffman_test_transitive(
  * \return AWS_OP_SUCCESS on success, AWS_OP_FAILURE on failure (error_string
  * will be set)
  */
+AWS_COMPRESSION_API
 int huffman_test_transitive_chunked(
     struct aws_huffman_symbol_coder *coder,
     const char *input,

--- a/source/huffman_testing.c
+++ b/source/huffman_testing.c
@@ -9,7 +9,7 @@
 /**
  * See aws/testing/compression/huffman.h for docs.
  */
-
+#define AWS_UNSTABLE_TESTING_API
 #include <aws/testing/compression/huffman.h>
 
 #include <aws/common/byte_buf.h>

--- a/source/huffman_testing.c
+++ b/source/huffman_testing.c
@@ -10,8 +10,10 @@
  * See aws/testing/compression/huffman.h for docs.
  */
 
-#include <aws/common/common.h>
+#include <aws/testing/compression/huffman.h>
+
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
 
 int huffman_test_transitive(
     struct aws_huffman_symbol_coder *coder,


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
