### PR TITLE
Fix build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - '!main'
 
 env:
-  BUILDER_VERSION: v0.8.9
+  BUILDER_VERSION: v0.8.19
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-compression

--- a/include/aws/testing/compression/huffman.h
+++ b/include/aws/testing/compression/huffman.h
@@ -6,11 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/testing/aws_test_harness.h>
-
 #include <aws/compression/huffman.h>
-
-#include <stddef.h>
 
 /**
  * The intended use of file is to allow testing of huffman character coders.

--- a/include/aws/testing/compression/huffman.h
+++ b/include/aws/testing/compression/huffman.h
@@ -96,6 +96,4 @@ int huffman_test_transitive_chunked(
     size_t output_chunk_size,
     const char **error_string);
 
-/*#include <aws/testing/compression/huffman.inl>*/
-
 #endif /* AWS_TESTING_COMPRESSION_HUFFMAN_H */

--- a/source/huffman_testing.c
+++ b/source/huffman_testing.c
@@ -10,6 +10,7 @@
  * See aws/testing/compression/huffman.h for docs.
  */
 #define AWS_UNSTABLE_TESTING_API
+#include <aws/testing/aws_test_harness.h>
 #include <aws/testing/compression/huffman.h>
 
 #include <aws/common/byte_buf.h>

--- a/tests/fuzz/decode.c
+++ b/tests/fuzz/decode.c
@@ -5,6 +5,7 @@
 
 #include <aws/compression/huffman.h>
 
+#include <aws/testing/aws_test_harness.h>
 #include <aws/testing/compression/huffman.h>
 
 struct aws_huffman_symbol_coder *test_get_coder(void);

--- a/tests/fuzz/transitive.c
+++ b/tests/fuzz/transitive.c
@@ -5,6 +5,7 @@
 
 #include <aws/compression/huffman.h>
 
+#include <aws/testing/aws_test_harness.h>
 #include <aws/testing/compression/huffman.h>
 
 struct aws_huffman_symbol_coder *test_get_coder(void);

--- a/tests/fuzz/transitive_chunked.c
+++ b/tests/fuzz/transitive_chunked.c
@@ -5,6 +5,7 @@
 
 #include <aws/compression/huffman.h>
 
+#include <aws/testing/aws_test_harness.h>
 #include <aws/testing/compression/huffman.h>
 
 struct aws_huffman_symbol_coder *test_get_coder(void);


### PR DESCRIPTION
aws-crt-java was complaining about macros pulled in through aws_test_harness.h (not 100% sure why).

In any case, aws_test_harness.h isn't needed here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
