### PR TITLE
fix build warnings

### DIFF
--- a/source/huffman_testing.c
+++ b/source/huffman_testing.c
@@ -10,7 +10,6 @@
  * See aws/testing/compression/huffman.h for docs.
  */
 #define AWS_UNSTABLE_TESTING_API
-#include <aws/testing/aws_test_harness.h>
 #include <aws/testing/compression/huffman.h>
 
 #include <aws/common/byte_buf.h>


### PR DESCRIPTION
Missed this in previous PR: https://github.com/awslabs/aws-c-compression/pull/47

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
