### PR TITLE
Fix warnings in public headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.40
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: header-warnings
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-compression
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: header-warnings
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.43
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-compression
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/include/aws/compression/compression.h
+++ b/include/aws/compression/compression.h
@@ -20,6 +20,8 @@ enum aws_compression_error {
     AWS_ERROR_END_COMPRESSION_RANGE = AWS_ERROR_ENUM_END_RANGE(AWS_C_COMPRESSION_PACKAGE_ID)
 };
 
+AWS_EXTERN_C_BEGIN
+
 /**
  * Initializes internal datastructures used by aws-c-compression.
  * Must be called before using any functionality in aws-c-compression.
@@ -34,6 +36,7 @@ void aws_compression_library_init(struct aws_allocator *alloc);
 AWS_COMPRESSION_API
 void aws_compression_library_clean_up(void);
 
+AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMPRESSION_COMPRESSION_H */

--- a/include/aws/compression/compression.h
+++ b/include/aws/compression/compression.h
@@ -10,6 +10,8 @@
 
 #include <aws/common/common.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #define AWS_C_COMPRESSION_PACKAGE_ID 3
 
 enum aws_compression_error {
@@ -31,5 +33,6 @@ void aws_compression_library_init(struct aws_allocator *alloc);
  */
 AWS_COMPRESSION_API
 void aws_compression_library_clean_up(void);
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMPRESSION_COMPRESSION_H */

--- a/include/aws/compression/compression.h
+++ b/include/aws/compression/compression.h
@@ -33,6 +33,7 @@ void aws_compression_library_init(struct aws_allocator *alloc);
  */
 AWS_COMPRESSION_API
 void aws_compression_library_clean_up(void);
+
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMPRESSION_COMPRESSION_H */

--- a/include/aws/compression/huffman.h
+++ b/include/aws/compression/huffman.h
@@ -10,6 +10,8 @@
 
 #include <aws/common/byte_buf.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 /**
  * Represents an encoded code
  */
@@ -157,5 +159,6 @@ AWS_COMPRESSION_API
 void aws_huffman_decoder_allow_growth(struct aws_huffman_decoder *decoder, bool allow_growth);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMPRESSION_HUFFMAN_H */


### PR DESCRIPTION
*Description of changes:*
- Adds `AWS_PUSH_SANE_WARNING_LEVEL` and `AWS_POP_SANE_WARNING_LEVEL` to the public headers. The public header should contain at least one include; otherwise, we will receive a macro not found error. Therefore, I decided to skip adding these macros if there are no includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.