### PR TITLE
Fix compiler warning

### DIFF
--- a/source/huffman.c
+++ b/source/huffman.c
@@ -282,4 +282,5 @@ int aws_huffman_decode(
 
     /* This case is unreachable */
     AWS_ASSERT(0);
+    return aws_raise_error(AWS_ERROR_INVALID_STATE);
 }


### PR DESCRIPTION
GCC 7.5 is reporting "control reaches end of non-void function" in Debug builds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
